### PR TITLE
Update FAQ link to Beginner's Guide and add Installation Guide

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
                     <li><a href="#home">Home</a></li>
                     <li><a href="#download">Download</a></li>
                     <li><a href="#community">Community</a></li>
-                    <li><a href="https://wiki.sp-tarkov.com/en/FAQs"><abbr title="Frequently Asked Questions">FAQ</abbr></a></li>
+                    <li><a href="https://wiki.sp-tarkov.com/Beginners_Guide"><abbr title="Beginner's Guide">FAQ</abbr></a></li>
                     <li><a href="https://forge.sp-tarkov.com/">Mods</a></li>
                     <li><a href="https://wiki.sp-tarkov.com">Wiki</a></li>
                     <li><a href="https://github.com/sp-tarkov">GitHub</a></li>
@@ -60,7 +60,7 @@
                     </ul>
                     <p>Take control of your Tarkov experience. Raid when you want, how you want.</p>
                     <p class="center">
-                        <a href="https://wiki.sp-tarkov.com/en/FAQs" class="btn">Read the FAQ</a>
+                        <a href="https://wiki.sp-tarkov.com/Installation_Guide" class="btn">Installation Guide</a>
                         <a href="#download" class="btn">Download Installer</a>
                     </p>
                 </article>

--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
                     <li><a href="#home">Home</a></li>
                     <li><a href="#download">Download</a></li>
                     <li><a href="#community">Community</a></li>
-                    <li><a href="https://wiki.sp-tarkov.com/Beginners_Guide"><abbr title="Beginner's Guide">FAQ</abbr></a></li>
+                    <li><a href="https://wiki.sp-tarkov.com/Beginners_Guide">Beginner's Guide</a></li>
                     <li><a href="https://forge.sp-tarkov.com/">Mods</a></li>
                     <li><a href="https://wiki.sp-tarkov.com">Wiki</a></li>
                     <li><a href="https://github.com/sp-tarkov">GitHub</a></li>


### PR DESCRIPTION
The website currently points to a dead url. Updating it to the current FAQ would also cause issues, as that page is version specific and would need updating. Changing it to the Beginner's Guide and Installation Guide would make it version agnostic, as those links wouldn't change with a SPT update.