### PR TITLE
Change the Discord invite link from a static invite to SPT's redirect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
                 <h1 id="communityTitle">Join Our Community</h1>
                 <article>
                     <p>Our Discord community welcomes all fans of <abbr title="Escape From Tarkov">EFT</abbr> and modding enthusiasts alike. We primarily focus on <abbr title="Single Player Tarkov">SPT</abbr> support and creative mod development. We're an inclusive, laid back community, <em>but we do have strict rules</em> which include no politics, no cheats, and no piracy; be sure to read the rules carefully after joining. Welcome!</p>
-                    <p class="center"><a href="https://discord.com/invite/Xn9msqQZan" class="btn">Join the <abbr title="Single Player Tarkov">SPT</abbr> Discord</a></p>
+                    <p class="center"><a href="http://discord.sp-tarkov.com/" class="btn">Join the <abbr title="Single Player Tarkov">SPT</abbr> Discord</a></p>
                 </article>
             </section>
         </main>

--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
                 <h1 id="communityTitle">Join Our Community</h1>
                 <article>
                     <p>Our Discord community welcomes all fans of <abbr title="Escape From Tarkov">EFT</abbr> and modding enthusiasts alike. We primarily focus on <abbr title="Single Player Tarkov">SPT</abbr> support and creative mod development. We're an inclusive, laid back community, <em>but we do have strict rules</em> which include no politics, no cheats, and no piracy; be sure to read the rules carefully after joining. Welcome!</p>
-                    <p class="center"><a href="http://discord.sp-tarkov.com/" class="btn">Join the <abbr title="Single Player Tarkov">SPT</abbr> Discord</a></p>
+                    <p class="center"><a href="https://discord.sp-tarkov.com/" class="btn">Join the <abbr title="Single Player Tarkov">SPT</abbr> Discord</a></p>
                 </article>
             </section>
         </main>


### PR DESCRIPTION
User reported the invite link present on the website to be invalid. While it worked when I tested it, the invite link is different from the one that's used by the redirect. To reduce the amount of invites needed to be maintained and verified working, they should both point to the same invite link.
However, this will prevent tracking of the number of users who use the website invite link vs. the redirect. If this metric is important to track, this pull request should be rejected.